### PR TITLE
Update gci.ipynb

### DIFF
--- a/gci.ipynb
+++ b/gci.ipynb
@@ -70,7 +70,7 @@
             " The energy of a photon with wavelength 123456.0 hertz is 6620.0e-34\n",
             " The energy of a photon with wavelength 111111.0 hertz is 72.82e-34\n",
             " The energy of a photon with wavelength 87654.0 hertz is 66.2e-34\n",
-            "Finished training model\n",
+            "Finished training the model\n",
             "[[73.07046]]\n",
             "These are the layer variables:[array([[6.6121845]], dtype=float32), array([6.948615], dtype=float32)]e-34\n"
           ],


### PR DESCRIPTION
This model calculates the energy of a photon after taking a frequency input, predicting planck's constant (h)
Energy=frequency*h